### PR TITLE
add ability to set the notification duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ like:
 
 You can use these methods with the following line of code
 
-`$notification.info(title, content, userData);`
-`$notification.warning(title, content, userData);`
-`$notification.error(title, content, userData);`
-`$notification.success(title, content, userData);`
+`$notification.info(title, content, userData, duration);`
+`$notification.warning(title, content, userData, duration);`
+`$notification.error(title, content, userData, duration);`
+`$notification.success(title, content, userData, duration);`
 
 **Title** is of course the title displayed in a large, bold text on the notification.
 **Content** is the additional detail text for that notification. The **userData** parameter
 is optional but allows you to store some data with a particular notification.
+
+**Duration** is optional (milliseconds): It allows you to set hhow long the notification is shown. Put `0` or `false` if you want a persistent notification. If not given it take the value in the setting.
 
 You can also use a generic notify method more inline with the standard chrome desktop
 notifications by specifying an image to display in the notification.

--- a/notification.js
+++ b/notification.js
@@ -111,24 +111,24 @@ angular.module('notifications', []).
 
       /* ============== NOTIFICATION METHODS ==============*/
 
-      info: function(title, content, userData){
+      info: function(title, content, userData, duration){
         console.log(title, content);
-        return this.awesomeNotify('info','info', title, content, userData);
+        return this.awesomeNotify('info','info', title, content, userData, duration);
       },
 
-      error: function(title, content, userData){
-        return this.awesomeNotify('error', 'remove', title, content, userData);
+      error: function(title, content, userData, duration){
+        return this.awesomeNotify('error', 'remove', title, content, userData, duration);
       },
 
-      success: function(title, content, userData){
-        return this.awesomeNotify('success', 'ok', title, content, userData);
+      success: function(title, content, userData, duration){
+        return this.awesomeNotify('success', 'ok', title, content, userData, duration);
       },
 
-      warning: function(title, content, userData){
-        return this.awesomeNotify('warning', 'exclamation', title, content, userData);
+      warning: function(title, content, userData, duration){
+        return this.awesomeNotify('warning', 'exclamation', title, content, userData, duration);
       },
 
-      awesomeNotify: function(type, icon, title, content, userData){
+      awesomeNotify: function(type, icon, title, content, userData, duration){
         /**
          * Supposed to wrap the makeNotification method for drawing icons using font-awesome
          * rather than an image.
@@ -139,16 +139,16 @@ angular.module('notifications', []).
          * through classes.
          */
         // image = '<i class="icon-' + image + '"></i>';
-        return this.makeNotification(type, false, icon, title, content, userData);
+        return this.makeNotification(type, false, icon, title, content, userData, duration);
       },
 
-      notify: function(image, title, content, userData){
+      notify: function(image, title, content, userData, duration){
         // Wraps the makeNotification method for displaying notifications with images
         // rather than icons
         return this.makeNotification('custom', image, true, title, content, userData);
       },
 
-      makeNotification: function(type, image, icon, title, content, userData){
+      makeNotification: function(type, image, icon, title, content, userData, duration){
         var notification = {
           'type': type,
           'image': image,
@@ -156,10 +156,13 @@ angular.module('notifications', []).
           'title': title,
           'content': content,
           'timestamp': +new Date(),
-          'userData': userData
+          'userData': userData,
+	  'duration': duration
         };
         notifications.push(notification);
-
+	if(duration == undefined) {
+	  duration = settings[type].duration;
+	}
         if(settings.html5Mode){
           html5Notify(image, title, content, function(){
             console.log("inner on display function");
@@ -169,10 +172,11 @@ angular.module('notifications', []).
         }
         else{
           queue.push(notification);
-          $timeout(function removeFromQueueTimeout(){
-            queue.splice(queue.indexOf(notification), 1);
-          }, settings[type].duration);
-
+	  if(duration){
+            $timeout(function removeFromQueueTimeout(){
+              queue.splice(queue.indexOf(notification), 1);
+            }, duration);
+	  }
         }
 
         this.save();


### PR DESCRIPTION
Add ability to set the notification duration and the persistence.

This is just a fix from https://github.com/DerekRies/angular-notifications/pull/8 (thanks to @pdf)

Usage:

$notification.info(title, content, userData, duration);

**Duration** is optional (milliseconds): It allows you to set how long the notification is shown. Put `0` or`false` if you want a persistent notification. If not given it take the value in the setting .

Thanks!
